### PR TITLE
Added api calls for adding a user.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ docker-ui-tests: clean build ## Build and run tests in container
 		--mount type=bind,source="${CURDIR}",target=/home/user/src \
 		"${DOCKER_TAG}"
 
-.PHONY: clean ui-tests
-ui-tests: ## Run tests outside of container
+.PHONY: ui-tests
+ui-tests: clean ## Run tests outside of container
 	@pipenv run pytest
 
 .PHONY: setup-redash

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ docker-ui-tests: clean build ## Build and run tests in container
 		--mount type=bind,source="${CURDIR}",target=/home/user/src \
 		"${DOCKER_TAG}"
 
-.PHONY: ui-tests
+.PHONY: clean ui-tests
 ui-tests: ## Run tests outside of container
 	@pipenv run pytest
 
 .PHONY: setup-redash
-setup-redash: ## Setup redash instance
+setup-redash: clean ## Setup redash instance
 	@docker-compose run --rm server create_db
 	@docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests"
-	@wget -q "${REDASH_SERVER_URL}setup" --post-data="name=Ashley McTest&email=ashley@example.com&password=REPLACE ME&org_name=default" -O /dev/null
+	@docker-compose run --rm server /app/manage.py users create_root root@example.com "rootuser" --password "IAMROOT" --org default
 
 .PHONY: bash
 bash: ## Run bash in container as user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pages.login import LoginPage
 @attr.s
 class User:
     """User represents a Redash user."""
+
     name = attr.ib(type=str)
     password = attr.ib(type=str)
     email = attr.ib(type=str)
@@ -31,74 +32,74 @@ def _verify_url(request, server_url, user, org):
     verify = request.config.option.verify_server_url
     if server_url and verify:
         session = requests.Session()
-        retries = Retry(backoff_factor=0.1,
-                        status_forcelist=[500, 502, 503, 504])
+        retries = Retry(backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
         session.mount(server_url, HTTPAdapter(max_retries=retries))
         session.get(server_url, verify=False)
 
 
-@pytest.fixture(name='server_url', scope='session')
+@pytest.fixture(name="server_url", scope="session")
 def fixture_server_url(request):
     """Return the URL to the Redash server."""
     return request.config.option.server_url
 
 
-@pytest.fixture(name='org', scope='session')
+@pytest.fixture(name="org", scope="session")
 def fixture_org():
     """Return the slug of an org."""
-    return 'default'
+    return "default"
 
 
-@pytest.fixture(name='unknown_user')
+@pytest.fixture(name="unknown_user")
 def fixture_unknown_user(variables, org):
     """Return a user that is not registered."""
-    return User(**variables[org]['users']['unknown'])
+    return User(**variables[org]["users"]["unknown"])
 
 
-@pytest.fixture(name='user', scope='session')
+@pytest.fixture(name="user", scope="session")
 def fixture_user(create_user, variables, org, users):
     """Return a registered user."""
-    user_info = variables[org]['users']['ashley']
+    user_info = variables[org]["users"]["ashley"]
     for user in users:
-        if user.email in user_info['email']:
+        if user.email in user_info["email"]:
             return user
     return create_user(**user_info)
 
 
-@pytest.fixture(name='users', scope='session')
+@pytest.fixture(name="users", scope="session")
 def fixture_users(variables, org, root_session, server_url):
-    response = root_session.get(f'{server_url}/api/users')
+    response = root_session.get(f"{server_url}/api/users")
     # check if user has any users within db, if not, they must run setup
     if response.status_code == 404:
-        raise RuntimeError("Root user must be created. "
-                           "Please run 'make setup-redash'")
+        raise RuntimeError("Root user must be created. Please run 'make setup-redash'")
     users = []
     for existing_user in response.json():
-        for user in variables[org]['users'].values():
-            if user['email'] == existing_user['email']:
-                users.append(User(
-                    user['name'],
-                    user['password'],
-                    user['email'],
-                    existing_user['id'],
-                ))
+        for user in variables[org]["users"].values():
+            if user["email"] == existing_user["email"]:
+                users.append(
+                    User(
+                        user["name"],
+                        user["password"],
+                        user["email"],
+                        existing_user["id"],
+                    )
+                )
     return users
 
 
-@pytest.fixture(name='root_user', scope='session')
+@pytest.fixture(name="root_user", scope="session")
 def fixture_root_user(variables, org):
     """Return the root user used for setup."""
-    return User(**variables[org]['users']['rootuser'])
+    return User(**variables[org]["users"]["rootuser"])
 
 
-@pytest.fixture(name='login_page')
+@pytest.fixture(name="login_page")
 def fixture_login_page(selenium, server_url, org):
     """Return a page object model for the login page."""
     login_page = LoginPage(selenium, server_url, org=org)
     return login_page.open()
 
 
-@pytest.fixture(name='create_user', scope='session')
+@pytest.fixture(name="create_user", scope="session")
 def fixture_create_user(root_session, server_url, users):
     """Return a function to create a user."""
 
@@ -118,37 +119,32 @@ def fixture_create_user(root_session, server_url, users):
                 User object that will be created.
 
         """
-        data = {
-            "name": name,
-            "email": email,
-            "no_invite": True,
-        }
+        data = {"name": name, "email": email, "no_invite": True}
         # look up user by email and return if found. If not, create user.
-        reponse = root_session.get(f'{server_url}/api/users')
+        reponse = root_session.get(f"{server_url}/api/users")
         for user in reponse.json():
-            if user['email'] is email:
-                return users[user['id']]
-        response = root_session.post(
-            f'{server_url}/api/users',
-            json=data)
+            if user["email"] is email:
+                return users[user["id"]]
+        response = root_session.post(f"{server_url}/api/users", json=data)
         if response.status_code != 200:
             raise RuntimeError(f"unable to create user: {response.text}")
         # add passwod to user
-        user_password = {'password': password}
+        user_password = {"password": password}
         try:
-            invite_link = (f"{response.json()['invite_link']}")
-            response = root_session.post(f'{server_url}{invite_link}',
-                                         data=user_password)
+            invite_link = f"{response.json()['invite_link']}"
+            response = root_session.post(
+                f"{server_url}{invite_link}", data=user_password
+            )
         except KeyError:
-            print(f'no invite link found. {response.text}')
+            raise RuntimeError(f"no invite link found. {response.text}")
         except Exception:
-            print(f"error sending invite: {response.text}")
+            raise RuntimeError(f"error sending invite: {response.text}")
         return User(name=name, email=email, password=password)
 
     return create_user
 
 
-@pytest.fixture(name='root_session', scope='session')
+@pytest.fixture(name="root_session", scope="session")
 def fixture_root_session(server_url, root_user):
     """Root login.
     
@@ -167,11 +163,10 @@ def fixture_root_session(server_url, root_user):
             Requests session used for api calls.
 
     """
-    url = f'{server_url}/login'
+    url = f"{server_url}/login"
     session = requests.Session()
-    response = session.post(url, data={
-        "email": root_user.email,
-        "password": root_user.password}
+    response = session.post(
+        url, data={"email": root_user.email, "password": root_user.password}
     )
     if response.status_code != 200:
         raise RuntimeError(f"unable to log in as root user: {response.text}")
@@ -180,19 +175,19 @@ def fixture_root_session(server_url, root_user):
 
 def pytest_addoption(parser):
     """Add custom options to pytest."""
-    group = parser.getgroup('redash')
+    group = parser.getgroup("redash")
 
     group.addoption(
-        '--server-url',
-        action='store',
-        dest='server_url',
+        "--server-url",
+        action="store",
+        dest="server_url",
         type=str,
-        default=os.getenv('REDASH_SERVER_URL', 'http://localhost:5000'),
+        default=os.getenv("REDASH_SERVER_URL", "http://localhost:5000"),
         help="URL to the Redash Server",
     )
     group.addoption(
-        '--verify-server-url',
-        action='store_true',
-        default=not os.getenv('VERIFY_SERVER_URL', 'false').lower() == 'false',
-        help='verify the server url.',
+        "--verify-server-url",
+        action="store_true",
+        default=not os.getenv("VERIFY_SERVER_URL", "false").lower() == "false",
+        help="verify the server url.",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,11 +55,10 @@ def fixture_unknown_user(variables, org):
 
 
 @pytest.fixture(name='user', scope='session')
-def fixture_user(variables, org, root_user, server_url):
+def fixture_user(api_session, variables, org, server_url):
     """Return a registered user."""
     user = User(**variables[org]['users']['ashley'])
-    session = _root_login(server_url, root_user)
-    create_user(server_url, session, user)
+    create_user(server_url, api_session, user)
     return user
 
 
@@ -110,7 +109,8 @@ def create_user(server_url, session, user):
         print("User {} was created.".format(user.name))
 
 
-def _root_login(server_url, user):
+@pytest.fixture(name='api_session', scope='session')
+def api_root_login_session(server_url, root_user):
     """Root login.
     
     This is only used to authenticate api calls as admin. It will login as the
@@ -131,8 +131,8 @@ def _root_login(server_url, user):
     url = "{}/login".format(server_url)
     session = requests.Session()
     session.post(url, data={
-        "email": "{}".format(user.email),
-        "password": "{}".format(user.password)}
+        "email": "{}".format(root_user.email),
+        "password": "{}".format(root_user.password)}
     )
     return session
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import attr
 import pytest
 import requests
+import json
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
@@ -36,7 +37,7 @@ def _verify_url(request, server_url, user, org):
         session.get(server_url, verify=False)
 
 
-@pytest.fixture(name='server_url')
+@pytest.fixture(name='server_url', scope='session')
 def fixture_server_url(request):
     """Return the URL to the Redash server."""
     return request.config.option.server_url
@@ -55,9 +56,18 @@ def fixture_unknown_user(variables, org):
 
 
 @pytest.fixture(name='user', scope='session')
-def fixture_user(variables, org):
+def fixture_user(variables, org, root_user, server_url):
     """Return a registered user."""
-    return User(**variables[org]['users']['ashley'])
+    user = User(**variables[org]['users']['ashley'])
+    session = _root_login(server_url, root_user)
+    create_user(server_url, session, user)
+    return user
+
+
+@pytest.fixture(name='root_user', scope='session')
+def fixture_root_user(variables, org):
+    """Return the root user used for setup."""
+    return User(**variables[org]['users']['root'])
 
 
 @pytest.fixture(name='login_page')
@@ -65,6 +75,67 @@ def fixture_login_page(selenium, server_url, org):
     """Return a page object model for the login page."""
     login_page = LoginPage(selenium, server_url, org=org)
     return login_page.open()
+
+
+def create_user(server_url, session, user):
+    """Create a user via api.
+
+    This will use the authenticated root user requests session to create a
+    user, accept the invite, and add a password.
+    
+    Args:
+        server_url: 
+            URL for redash instance
+        session: 
+            Requests login session. 
+            This is needed to allow for user creation.
+        user:
+            User object that will be created.
+
+    """
+    url = server_url + '/api/users'
+    data = json.dumps({
+        "name": "{}".format(user.name),
+        "email": "{}".format(user.email),
+        "no_invite": True,
+    })
+    response = session.post(url, data=data)
+    user_password = {'password': "{}".format(user.password)}
+    try:
+        invite_url = ('{}{}'.format(server_url,
+                                    response.json()['invite_link']))
+        session.post(invite_url, data=user_password)
+    except Exception:
+        pass
+    if response.status_code == 200:
+        print("User {} was created.".format(user.name))
+
+
+def _root_login(server_url, user):
+    """Root login.
+    
+    This is only used to authenticate api calls as admin. It will login as the
+    root user and return a requests session that can be used to create/delete
+    other users as well as other actions.
+
+    Args:
+        server_url:
+            URL for redash instance.
+        user:
+            User object that will be created.
+
+    Returns:
+        session:
+            Requests session used for api calls.
+
+    """
+    url = "{}/login".format(server_url)
+    session = requests.Session()
+    session.post(url, data={
+        "email": "{}".format(user.email),
+        "password": "{}".format(user.password)}
+    )
+    return session
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def fixture_user(create_user, variables, org, users):
     """Return a registered user."""
     user_info = variables[org]["users"]["ashley"]
     for user in users:
-        if user.email in user_info["email"]:
+        if user.email == user_info["email"]:
             return user
     return create_user(**user_info)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import os
 import attr
 import pytest
 import requests
-import json
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
@@ -94,12 +93,12 @@ def create_user(server_url, session, user):
 
     """
     url = server_url + '/api/users'
-    data = json.dumps({
+    data = {
         "name": "{}".format(user.name),
         "email": "{}".format(user.email),
         "no_invite": True,
-    })
-    response = session.post(url, data=data)
+    }
+    response = session.post(url, json=data)
     user_password = {'password': "{}".format(user.password)}
     try:
         invite_url = ('{}{}'.format(server_url,

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -8,20 +8,20 @@ import pytest
 @pytest.mark.nondestructive
 def test_login_wrong_user_credentials(login_page, unknown_user):
     """Test for a failed login attempt."""
-    assert login_page.title == 'Login to Redash'
+    assert login_page.title == "Login to Redash"
 
     login_page.login(email=unknown_user.email, password=unknown_user.password)
 
-    assert login_page.alert == 'Wrong email or password.'
-    assert login_page.title == 'Login to Redash'
+    assert login_page.alert == "Wrong email or password."
+    assert login_page.title == "Login to Redash"
 
 
 @pytest.mark.nondestructive
 def test_login(login_page, user):
     """Test for a successful login attempt."""
-    assert login_page.title == 'Login to Redash'
+    assert login_page.title == "Login to Redash"
 
     login_page.login(email=user.email, password=user.password)
 
     assert login_page.profile_dropdown == user.name
-    assert login_page.title == 'Redash'
+    assert login_page.title == "Redash"

--- a/variables.json
+++ b/variables.json
@@ -10,6 +10,11 @@
         "name": "Ashley McTest",
         "email": "ashley@example.com",
         "password": "REPLACE ME"
+      },
+      "root": {
+	"name": "rootuser",
+	"email": "root@example.com",
+	"password": "IAMROOT"
       }
     }
   }

--- a/variables.json
+++ b/variables.json
@@ -11,7 +11,7 @@
         "email": "ashley@example.com",
         "password": "REPLACE ME"
       },
-      "root": {
+      "rootuser": {
 	"name": "rootuser",
 	"email": "root@example.com",
 	"password": "IAMROOT"


### PR DESCRIPTION
This works on the setup/teardown issue, but we have ran into restrictions for teardown that will have to be fixed later. Please see this [issue](https://github.com/mozilla/redash-ui-tests/issues/3).

* Added all the api calls to create and authenticate a user.
* Added doc strings to new functions/fixtures

For the api to allow for a user to be added, I must login as the ```root``` user and then return that login session to be used to create other users.

Concerns
----------
I changed the ```server_url``` fixture to session as I don't see why it would change between tests. It makes sense that one URL should be used for all the tests.