### PR TITLE
Updates to use Mozilla redash docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build: clean ## Build Docker image
 
 .PHONY: docker-ui-tests
 docker-ui-tests: clean ## Run tests in container and copy report.html
+	@docker rm redash-ui-tests
 	@docker run \
 		--net="host" \
 		--name "redash-ui-tests" \
@@ -55,7 +56,7 @@ setup-redash: clean ## Setup redash instance
 		--rm server /app/manage.py ds new \
 		"ui-tests" \
 		--type "url" \
-		--options '{"title": "uitests"}'
+		--options '{"url": "uitests"}'
 
 .PHONY: bash
 bash: ## Run bash in container as user

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ build: clean ## Build Docker image
 
 .PHONY: docker-ui-tests
 docker-ui-tests: clean ## Run tests in container and copy report.html
-	@docker rm redash-ui-tests
 	@docker run \
 		--net="host" \
 		--name "redash-ui-tests" \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ Check out who has already contributed to **redash-ui-tests**
 [first]: https://github.com/mozilla/redash-ui-tests/labels/good%20first%20issue
 [git]: https://git-scm.com/
 [redash help]: https://redash.io/help/
-[redash]: https://wiki.mozilla.org/Telemetry/Custom_dashboards_with_re:dash
+[redash]: https://docs.telemetry.mozilla.org/tools/stmo.html
 [tests]: https://github.com/mozilla/redash-ui-tests/issues?q=is%3Aissue+is%3Aopen+label%3Atests
 [docs]: https://redash-ui-tests.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redash-ui-tests
 
-:bar_chart: UI tests for [Redash][redash]
+:bar_chart: UI tests for Mozilla [Redash][redash]
 
 ## Description
 
@@ -44,6 +44,6 @@ Check out who has already contributed to **redash-ui-tests**
 [first]: https://github.com/mozilla/redash-ui-tests/labels/good%20first%20issue
 [git]: https://git-scm.com/
 [redash help]: https://redash.io/help/
-[redash]: https://github.com/getredash/redash
+[redash]: https://wiki.mozilla.org/Telemetry/Custom_dashboards_with_re:dash
 [tests]: https://github.com/mozilla/redash-ui-tests/issues?q=is%3Aissue+is%3Aopen+label%3Atests
 [docs]: https://redash-ui-tests.readthedocs.io/en/latest/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,11 @@ services:
     links:
       - "server:redash"
   server:
-    image: redash/redash:latest
+    image: mozilla/redash:latest
     command: dev_server
     depends_on:
       - postgres
       - redis
-    volumes:
-      - server:/app
     ports:
       - "5000:5000"
     environment:
@@ -28,7 +26,7 @@ services:
       REDASH_GOOGLE_CLIENT_SECRET: "dummy"
     restart: always
   worker:
-    image: redash/redash:latest
+    image: mozilla/redash:latest
     command: scheduler
     depends_on:
       - server
@@ -46,5 +44,3 @@ services:
     image: postgres:9.5.6-alpine
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
-volumes:
-  server:

--- a/pages/queries.py
+++ b/pages/queries.py
@@ -66,7 +66,8 @@ class QueryDetailPage(Page):
         for item in (i for i in items if i.text in text):
             if text == "Fork":
                 item.click()
-                return QueryDetailPage(self.selenium, self.base_url).wait_for_page_to_load()
+                page = QueryDetailPage(self.selenium, self.base_url)
+                return page.wait_for_page_to_load()
             if text == "Archive":
                 item.click()
                 self.find_element(*self._query_modal_archive_locator).click()

--- a/pages/queries.py
+++ b/pages/queries.py
@@ -19,7 +19,7 @@ class QueryDetailPage(Page):
     )
     _query_description_locator: Locator = (
         By.CSS_SELECTOR,
-        "edit-in-place:nth-child(1) > span:nth-child(1) > p:nth-child(1)",
+        "div.query-metadata:nth-child(3) > edit-in-place:nth-child(1)",
     )
     _query_description_blank_locator: Locator = (
         By.CSS_SELECTOR,
@@ -66,7 +66,7 @@ class QueryDetailPage(Page):
         for item in (i for i in items if i.text in text):
             if text == "Fork":
                 item.click()
-                return QueryDetailPage(self.selenium, self.base_url)
+                return QueryDetailPage(self.selenium, self.base_url).wait_for_page_to_load()
             if text == "Archive":
                 item.click()
                 self.find_element(*self._query_modal_archive_locator).click()


### PR DESCRIPTION
Fixes #108 

This switches redash-ui-tests to using mozilla's fork of Redash. Also updated a link in the docs to point to the Mozilla Redash wiki page.