### PR TITLE
Correct the command to build the UI tests in the getting-started.md file

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -22,14 +22,14 @@ page][git-downloads].
 
 ### Clone project
 
-Open a terminal and type ``git clone`` and the URL to **redash-ui-tests**:
+Open a terminal and type `git clone` and the URL to **redash-ui-tests**:
 
 ```text
 $ git clone https://github.com/mozilla/redash-ui-tests
 ```
 
 This will download the latest version of the source code to your local
-machine to a new directory named ``redash-ui-tests``.
+machine to a new directory named `redash-ui-tests`.
 
 Navigate to the project:
 
@@ -43,11 +43,11 @@ with the tests.
 #### Redash Setup
 
 The redash instance must be setup before running the tests. Start the images
-``docker-compose up -d`` in the root of the directory in which the project
+`docker-compose up -d` in the root of the directory in which the project
 was downloaded to. This will download the images if you don't have them. It
 will also start the container in the background. You can view the status of
-the containers via ``docker-compose ps``. You can also stop the docker
-container by running ``docker-compose stop``.
+the containers via `docker-compose ps`. You can also stop the docker
+container by running `docker-compose stop`.
 
 All the following commands should also be run within the same directory that
 you downloaded the project to.
@@ -66,30 +66,30 @@ docker-compose run --rm server create_db
 docker-compose run --rm postgres psql -h postgres -U postgres -c "create database tests"
 ```
 
-3. Create a default user named ``rootuser`` with a password ``IAMROOT`` and
-an organization ``default``:
+3. Create a default user named `rootuser` with a password `IAMROOT` and
+   an organization `default`:
 
 ```text
 docker-compose run --rm server /app/manage.py users create_root root@example.com "rootuser" --password "IAMROOT" --org default
 ```
 
-4. Create a new data source named ``ui-tests``.
+4. Create a new data source named `ui-tests`.
 
 ```text
 docker-compose run --rm server /app/manage.py ds new "ui-tests" --type "url" --options '{"title": "uitests"}'
 ```
 
-You can visit ``127.0.0.1:5000``, or ``localhost:5000`` in a web browser to
+You can visit `127.0.0.1:5000`, or `localhost:5000` in a web browser to
 see the redash login page.
 
-___
+---
 
 #### Docker test
 
 Build the redash-ui-tests with this command:
 
 ```text
-docker build -t "redash-ui-tests:latest"
+docker build -t "redash-ui-tests:latest" .
 ```
 
 Then run the tests:
@@ -105,7 +105,7 @@ command
 docker cp ui-tests:/home/user/src/report.html ./report.html
 ```
 
-and open the ```report.html```, which should be located within the projects
+and open the `report.html`, which should be located within the projects
 root directory, in your web browser.
 
 #### Using make
@@ -114,9 +114,9 @@ Redash-ui-tests include a Makefile to run setup and tests.
 
 ##### Make commands
 
-To setup the redash instance us:e ```make setup-redash```.
-To run the docker tests use: ```make docker-ui-tests```.
-To run the tests using a local firefox browser use: ```make ui-tests```.
+To setup the redash instance us:e `make setup-redash`.
+To run the docker tests use: `make docker-ui-tests`.
+To run the tests using a local firefox browser use: `make ui-tests`.
 
 ## Break a test
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/redash-ui-tests/issues/98

I have just added a  "."  at the end of line 92 which now looks like this:
docker build -t "redash-ui-tests:latest" .
